### PR TITLE
Changed manage.py file

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,7 @@ import sys
 
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ServiceStatus.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ServiceStatus.settings-dev')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asgiref==3.2.7
 # astroid==2.3.3
 astroid==2.4.1
-Django==3.0.6
+Django==3.0.5
 gunicorn
 django-admin-list-filter-dropdown==1.0.3
 django-ckeditor==5.9.0


### PR DESCRIPTION
In the current manage.py file it has a reference to ServiceStatus.settings. When you run the server you run into an error stating that there is no such module ServiceStatus.settings. The reason behind this is because the settings file in ServiceStatus is called settings-dev.py. 

I changed the manage.py file to have a reference to ServiceStatus.settings-dev.