### PR TITLE
Support for inter and multi domain services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ sent_emails/*.log
 coverage.xml
 *.cover
 .coveragerc
+status/migrations/0044_service_scope.py

--- a/status/admin.py
+++ b/status/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django_admin_listfilter_dropdown.filters import DropdownFilter, RelatedDropdownFilter
+from django_admin_listfilter_dropdown.filters import ChoiceDropdownFilter, DropdownFilter, RelatedDropdownFilter
 
 from status.forms import TicketHistoryInlineFormset, TicketForm, SubscriberForm
 from .models import ClientDomain
@@ -47,7 +47,7 @@ class ClientDomainAdmin(admin.ModelAdmin):
 
 @admin.register(Service)
 class ServiceAdmin(admin.ModelAdmin):
-    list_display = ('name', 'description',)
+    list_display = ('name', 'description', 'scope_type')
     search_fields = ['name', 'service_description', 'topology__subservices__name',
                      'clientdomain__region__name']
     list_filter = (('topology__subservices__ticket__status__tag',
@@ -57,7 +57,9 @@ class ServiceAdmin(admin.ModelAdmin):
                    ('clientdomain__name',
                     DropdownFilter),
                    ('topology__subservices__name',
-                    DropdownFilter))
+                    DropdownFilter),
+                    ('scope', 
+                    ChoiceDropdownFilter))
     ordering = ['name']
 
 

--- a/status/admin.py
+++ b/status/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django_admin_listfilter_dropdown.filters import ChoiceDropdownFilter, DropdownFilter, RelatedDropdownFilter
 
-from status.forms import TicketHistoryInlineFormset, TicketForm, SubscriberForm
+from status.forms import TicketHistoryInlineFormset, TicketForm, SubscriberForm, ClientDomainForm
 from .models import ClientDomain
 from .models import EmailDomain
 from .models import Priority
@@ -32,6 +32,7 @@ class RegionAdmin(admin.ModelAdmin):
 
 @admin.register(ClientDomain)
 class ClientDomainAdmin(admin.ModelAdmin):
+    form = ClientDomainForm
     list_display = ('name', 'description',)
     search_fields = ['name', 'domain_description']
     list_filter = (('services__topology__subservices__ticket__status__tag',
@@ -41,6 +42,8 @@ class ClientDomainAdmin(admin.ModelAdmin):
                    ('services__name',
                     DropdownFilter),
                    ('services__topology__subservices__name',
+                    DropdownFilter),
+                    ('services__scope',
                     DropdownFilter))
     ordering = ['name']
 

--- a/status/forms.py
+++ b/status/forms.py
@@ -12,6 +12,37 @@ from .models import SubService
 from .models import Subscriber
 from .models import Ticket
 from .models import Topology
+from .models import ClientDomain
+
+
+class ClientDomainForm(forms.ModelForm):
+
+    def clean(self):
+        services = self.cleaned_data['services']
+        
+        tmp_inter_services = []  # list to hold inter-domain services chosen by user
+
+        for service in services:
+            if service.scope == Service.INTER_DOMAIN:
+                # tmp_inter_services.append(service.name)
+                
+                """
+                if user chose more than 1 inter-domain service
+                currently the feature is not needed, but will be
+                left here commented out if that feature is needed
+                in the future
+                """
+                # if len(tmp_inter_services) > 1:  
+                #     self.add_error("services", "Only 1 inter-domain service can be chosen. \
+                #             Please choose between " + " and ".join(tmp_inter_services))
+                #     raise ValidationError("There are some errors in services")
+
+                # check if it is already taken by another client domain
+                if ClientDomain.objects.filter(services__in=[service]) \
+                        .exclude(name=self.instance).exists():
+                    self.add_error("services", "{} is an inter-domain service and has  \
+                                already been taken.".format(service))
+                    raise ValidationError("There are some errors in services")
 
 
 class EmailActions:

--- a/status/models.py
+++ b/status/models.py
@@ -18,9 +18,17 @@ class Service(models.Model):
         - The Service name will be mandatory, but no the description field.
         - The name field could have a maximum of 100 characters.
         - The description field will store an HTML enriched text content.
+        - The scope field will identify if service is inter-domain or multi-domain
     """
+    MULTI_DOMAIN = "multi_domain"
+    INTER_DOMAIN = "inter_domain"
+    DOMAIN_CHOICES = [
+        (MULTI_DOMAIN, "Multi-Domain"),
+        (INTER_DOMAIN, "Inter-Domain")  
+    ]
     name = models.CharField(unique=True, max_length=100, verbose_name='Service')
     service_description = RichTextField(blank=True, null=True, verbose_name='Description')
+    scope = models.CharField(max_length=30, choices=DOMAIN_CHOICES, default=MULTI_DOMAIN, blank=True)
 
     def description(self):
         """
@@ -44,6 +52,9 @@ class Service(models.Model):
 
     def __str__(self):
         return self.name
+    
+    def scope_type(self):
+        return str(self.scope).upper()
 
 
 class ClientDomain(models.Model):


### PR DESCRIPTION
This pull request satisfies the following milestones:

1) Support for inter and multi domain services:
* This will require modifying the backend, specifically the service creation.
* A service will be capable of being inter-domain or multi-domain. An inter-domain service can be assigned to just one client domain entry; therefore, relationship creations between services and domains must consider this condition.
* The service model/table should include a new attribute to specify the service “scope” (inter-domain or multi-domain). We should verify the service type every time services are listing on the client-domain module. If it is an inter-domain service, that service is free to be used; otherwise, there is no need to list it.

2) Filtering option
*Create a filtering option on the admin site to list services by type (multi-domain / inter-domain)