### PR TITLE
Extension of Ticket creation to services and domains

### DIFF
--- a/status/admin.py
+++ b/status/admin.py
@@ -114,6 +114,7 @@ class TicketAdmin(admin.ModelAdmin):
     list_display = ('ticket_id', 'sub_service', 'status', 'begin', 'end', 'notify_action',)
 
     fieldsets = [
+        # ('Sub-Service on process', {'fields': ['ticket_id', 'client_domain', 'services', 'sub_services', 'status']}),
         ('Sub-Service on process', {'fields': ['ticket_id', 'sub_service', 'status']}),
         ('Date information', {'fields': ['begin', 'end']}),
         ('Additional Information', {'fields': ['action_description', 'action_notes']}),

--- a/status/forms.py
+++ b/status/forms.py
@@ -254,6 +254,15 @@ class TicketForm(forms.ModelForm):
 
     cleaned_data = None
 
+    # client_domain = forms.ModelChoiceField(
+    #     queryset=ClientDomain.objects.all(),
+    #     required=False
+    # )
+
+    # services = forms.ModelMultipleChoiceField(
+    #     queryset=Service.objects.all(),
+    #     required=False)
+
     class Meta:
         model = Ticket
         fields = '__all__'
@@ -318,6 +327,44 @@ class TicketForm(forms.ModelForm):
                     self.instance.user_notified = True
                 except Exception as e:
                     print(e)  # we should log this as an error
+
+            # if self.cleaned_data['client_domain']:
+            #     # all services under the domain are affected
+            #     # all sub-services under each service is also
+            #     # affected
+
+            #     # client domain chosen by user
+            #     client_domain = self.cleaned_data['client_domain']
+
+            #     # |= allows us to create a union of querysets
+            #     # This allows for us to add on to the services
+            #     # if the user already chooses a service or
+            #     # services.
+            #     self.cleaned_data['services'] |= client_domain.services.all()
+
+            # if self.cleaned_data['services']:
+            #     # associated_sub_services
+            #     services = self.cleaned_data['services']
+
+            #     querysets = []
+            #     for service in services:
+
+            #         # get sub service under service from Topology
+            #         if Topology.objects.filter(service=service).values('subservices').exists():
+            #             topology_queryset = Topology.objects.filter(
+            #                 service=service)
+            #             for topology in topology_queryset:
+            #                 querysets.append(topology.subservices.all())
+
+            #     result_queryset = SubService.objects.none()
+            #     for query in querysets:
+            #         result_queryset = result_queryset | query
+
+            #     # |= allows us to create a union of querysets
+            #     # This allows for us to add on to the subservices
+            #     # if the user already chooses a sub-service or
+            #     # sub-services.
+            #     self.cleaned_data['sub_services'] |= result_queryset
 
 
 class TicketHistoryInlineFormset(forms.models.BaseInlineFormSet):

--- a/status/models.py
+++ b/status/models.py
@@ -271,6 +271,10 @@ class Ticket(models.Model):
 
     ticket_id = models.CharField(unique=True, max_length=10, default=get_new_ticket_id)
 
+    # sub-service to sub-services
+    # sub_services = models.ManyToManyField(SubService, blank=True, verbose_name='Sub-Services')
+
+
     # This action (models.SET_NULL) will allow keeping tickets regardless of
     # the deletion of the sub-service where they belong.
     sub_service = models.ForeignKey(SubService, models.SET_NULL,
@@ -313,6 +317,8 @@ class TicketLog(models.Model):
 
     def __str__(self):
         return "{0} in {1}".format(self.ticket.sub_service, self.ticket.ticket_id)
+        # adjust ticket log for sub_services
+        # return "{0} in {1}".format(self.ticket.sub_services.all(), self.ticket.ticket_id)
 
 
 class Subscriber(models.Model):


### PR DESCRIPTION
The ticket model now includes the new field sub_services, which is a ManytoMany field. This will allow a ticket to have 1 or many services. The form for ticket include two extra fields, services and client domain. The user will be able to choose a client domain and have all the sub-services under each service for that domain chosen. The user will also have the flexibility of choosing additional services not under that domain and additional services.  The extra fields can be shown by placing them in the fields for admin.py

In order for those changes to be implemented, the frontend will need to change, in additional to some forms on the backend. There may be other changes needed as well. 