### PR TITLE
Fixed ticket details page, subscription page, table headers dark mode…

### DIFF
--- a/status/static/css/style.css
+++ b/status/static/css/style.css
@@ -15,6 +15,7 @@ html, body {
     color: white;
 }
 
+
 .navbar {
     font-family: 'Fira Sans', sans-serif;
 }
@@ -26,9 +27,20 @@ html, body {
 
 .eventDarkMode {
     filter:invert(100);
-    background-color: #333333;
-    color: white;
+    background-color: #333333 !important;
+    color: #ddd !important;
 }
+
+.eventDarkMode span {
+    color: #ddd !important;
+}
+
+.tableHeaderDM {
+    background-color: #CCCCCC !important;
+    color: #000;
+}
+
+
 
 .link {
     color: #0373fc;
@@ -108,6 +120,10 @@ a:hover {
 
 #list_of_services_data {
     overflow: hidden;
+}
+
+#list_of_services_heading {
+    background-color: #E9ECEF;
 }
 
 #specific_service {

--- a/status/static/js/darkmode.js
+++ b/status/static/js/darkmode.js
@@ -17,19 +17,33 @@ let cssToggle = () => {
     var footer = document.getElementById("footer");
     var brand = document.getElementById("navBarLogo");
     var events = document.getElementsByClassName("ticket-instance");
+    var tableHeader = document.getElementById("list_of_services_heading");
+    var legendHeader = document.getElementById("legend_header");
 
-    for (let i = 0; i < list.length; i++){
-        list[i].classList.toggle("darkmode");
-    }
-
-    for (let i = 0; i < events.length; i++){
-        events[i].classList.toggle("list_events");
-        events[i].classList.toggle("eventDarkMode");
-    }
     html.classList.toggle("darkmode");
     footer.classList.toggle("darkmode");
     brand.classList.toggle("darkmode");
     brand.classList.toggle("brighten");
+
+    var currentUrl = window.location.pathname;
+    if (currentUrl === "/"){
+        tableHeader.classList.toggle("tableHeaderDM");
+        legendHeader.classList.toggle("tableHeaderDM");
+            for (let i = 0; i < list.length; i++){
+                list[i].classList.toggle("darkmode");
+            }
+
+            for (let i = 0; i < events.length; i++){
+                events[i].classList.toggle("list_events");
+                events[i].classList.toggle("eventDarkMode");
+            }
+    } else if (currentUrl.includes("/subscription/")) {
+        var subscriptions = document.getElementById("subscribe");
+        subscriptions.classList.toggle("eventDarkMode");
+    } else if (currentUrl.includes("/details/")){
+        var tickets = document.getElementById("ticket_info");
+        tickets.classList.toggle("eventDarkMode");
+    }
 }
 
 if (window.localStorage.getItem('darkmode') == "t") {

--- a/status/templates/services_status.html
+++ b/status/templates/services_status.html
@@ -22,7 +22,7 @@
                 <a href="details/{{ ticket.id }}">
                     <p><span class="bold">Sub-service Impacted: </span>{{ ticket.sub_service.name }}</p>
                     <p><span class="bold">Status: </span>{{ ticket.status.tag }}</p>
-                    <p>{{ ticket.action_description | safe }}</p> <!--  Description of the ticket  -->
+                    <p id="ticket_description">{{ ticket.action_description | safe }}</p> <!--  Description of the ticket  -->
                 </a>
             </div>
 
@@ -207,7 +207,7 @@
             <div class="col-2 d-none d-lg-inline">
                 <!--  Legend section  -->
                 <div class="container ml-2 border-left border-right border-bottom">
-                    <div class="row py-1 border legend_heading">
+                    <div class="row py-1 border legend_heading" id="legend_header">
                         <p class="bold my-1 pl-2">Legend</p>
                     </div>
 

--- a/status/templates/sh_details.html
+++ b/status/templates/sh_details.html
@@ -13,7 +13,7 @@
 
                 <!--  Ticket main information section  -->
                 <p><span class="bold">Sub-service affected:</span> {{ object.sub_service }}</p>
-                <div class="container mb-1 border-bottom py-2 mb-4"
+                <div class="container mb-1 py-2 mb-4"
                      style="border-left: 0.4rem solid {{ object.status.color_hex }};"
                      id="ticket_info">
                     <div class="row px-3 pt-3 d-flex justify-content-between">
@@ -23,7 +23,7 @@
                             {{ instance.ticket_id }}</p>
                         <p class="bold" data-toggle="tooltip" data-placement="top"
                            title="{{ object.status.tag }}">
-                            <span style="color: {{ object.status.color_hex }}">
+                            <span style="color: {{ object.status.color_hex }} !important">
                                 <i class="{{ object.status.class_design }}"></i>
                             </span>
                         </p>

--- a/status/templates/subscription.html
+++ b/status/templates/subscription.html
@@ -4,7 +4,7 @@
 
     <div class="container d-flex align-items-center justify-content-center mt-4 mb-2" id="subscription_page">
         <div class="row d-flex justify-content-center">
-            <div class="col-sm-12{% if not service_specific %} col-lg-6{% endif %} m-4 pt-4" id="subscribe">
+            <div class="col-sm-12{% if not service_specific %} col-lg-6{% endif %} m-4 pt-4 list_events" id="subscribe">
                 <div class="container mb-3 border-bottom">
                     <h1>Subscribe to Services Updates</h1>
                 </div>


### PR DESCRIPTION

1. Table headers on "/" added color #E9ECEF, #333333 in darkmode.
2. Font colors of tickets is completely white in dark mode, will remain whatever specified color on lightmode.  The text coming to ticket descriptions is from description tag in database, comes with html tags and inline style - difficult to work around but fixed. 
3. Subscription page now has table colored #E9ECEF in lightmode, #333333 in darkmode.
4. Fixed some logic on extra pages not inverting properly in darkmode, specifically "/details/" pages with ticket information, now maintains style of rest of darkmode.