### PR TITLE
Addded Action Date to Planned tickets, as well as On-Process logic

### DIFF
--- a/status/models.py
+++ b/status/models.py
@@ -9,6 +9,8 @@ from django.db import models
 from django.utils.html import format_html
 from django.utils.text import Truncator
 from django.utils.translation import ugettext_lazy as _
+from datetime import datetime
+import pytz
 
 
 class Service(models.Model):
@@ -304,6 +306,11 @@ class Ticket(models.Model):
     class Meta:
         verbose_name = _("Ticket")
         verbose_name_plural = _("Tickets")
+
+    @property
+    def is_in_process(self):
+        localized_current_time = datetime.now(pytz.utc)
+        return localized_current_time > self.begin
 
     def __str__(self):
         # return "{0} in {1}".format(self.service_category, self.business_service)

--- a/status/templates/services_status.html
+++ b/status/templates/services_status.html
@@ -32,7 +32,16 @@
                     <div class="clearfix"></div>
 
                     </p>
-                    <p><span class="bold">Status: </span>{{ ticket.status.tag }}</p>
+                    <p><span class="bold">Status: </span>
+                        {% if ticket.status.tag == "Planned" and ticket.is_in_process %}
+                            On Process
+                        {% else %}
+                            {{ ticket.status.tag }}
+                        {% endif %}
+                    </p>
+                    {% if ticket.status.tag == "Planned" %}
+                    <p><span class="bold">Action Date: </span>{{ ticket.begin }}</p>
+                    {% endif %}
                     <p id="ticket_description">{{ ticket.action_description | safe }}</p> <!--  Description of the ticket  -->
                 </a>
 


### PR DESCRIPTION
Tickets with a status of 'Planned' will display an 'Action Date' below the status, with the specified begin time for the ticket.  Tickets which are planned and the current datetime (using utc) is greater than the begin time will display 'On Process'.  'On Process' will display until ticket status is changed from Planned to any other status, no logic is implemented for exiting On Process, it is solely reliant on the ticket status being changes from Planned.  